### PR TITLE
Allow null for created at

### DIFF
--- a/api/app/Http/Resources/FormSubmissionResource.php
+++ b/api/app/Http/Resources/FormSubmissionResource.php
@@ -41,7 +41,7 @@ class FormSubmissionResource extends JsonResource
     {
         $this->data = array_merge($this->data, [
             'status' => $this->status,
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at ? $this->created_at->toDateTimeString() : null,
             'id' => $this->id,
         ]);
     }


### PR DESCRIPTION
My get submissions api call is crashing since some or the rows' created at is null
This will prevent api call crashing 